### PR TITLE
APIに送る値をadditional.co2からadditional.info.co2に変えた

### DIFF
--- a/app/send_beacon.sh
+++ b/app/send_beacon.sh
@@ -43,7 +43,7 @@ tail -n 1 /var/local/co2mon/DATA/log/gps_tpv |
   jq '{"lat": .lat, "lng": .lon, "alt": .alt, "direction": 0}' |
   #jq --arg type "${type}" '. + {"type": $type}' |
   jq --arg type "default" '. + {"type": $type}' |
-  jq --arg co2 "${co2}" '. + {"additional": {"co2": $co2}}' |
+  jq --arg co2 "${co2}" '. + {"additional": {"info": {"co2": $co2}}}' |
   curl -s -w '\n' -H "Content-type: application/json" -d @- "${info_url}?token=${token}"
 
 # ここで通常の終了処理


### PR DESCRIPTION
※ 動作確認はしていない

実は`beacon.additional.info`に情報を入れるとそのままHec-Eye側の画面に表示されるという仕様があったのです。

参考：

* https://github.com/realglobe-Inc/hec-eye/issues/1712
* https://github.com/realglobe-Inc/hec-eye/pull/2463

