### PR TITLE
2020-05-27-raspios-buster-lite-armhf に対応した

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,9 @@ docker buildx inspect --bootstrap  # 最初の1回のみ
 microSDの書き込み
 
 ```sh
-diskutil unmountDisk /dev/disk2
-sudo dd if=~/Downloads/2020-02-13-raspbian-buster-lite.img of=/dev/rdisk2 bs=1m; say 'オワッタヨ'
-touch /Volumes/boot/ssh
-diskutil eject /dev/disk2
+wget http://downloads.raspberrypi.org/raspios_lite_armhf/images/raspios_lite_armhf-2020-05-28/2020-05-27-raspios-buster-lite-armhf.zip
+unzip 2020-05-27-raspios-buster-lite-armhf.zip
+./write_sd.sh
 ```
 
 起動してシェルログインできたら、以下のコマンドを実行する。

--- a/setup_raspberrypi.sh
+++ b/setup_raspberrypi.sh
@@ -215,82 +215,82 @@ noipv6rs
 static domain_name_servers=8.8.8.8 8.8.4.4
 EOF
 
-# config.txt
-sudo tee /boot/config.txt > /dev/null <<'EOF'
-# For more options and information see
-# http://rpf.io/configtxt
-# Some settings may impact device functionality. See link above for details
-
-# uncomment if you get no picture on HDMI for a default "safe" mode
-#hdmi_safe=1
-
-# uncomment this if your display has a black border of unused pixels visible
-# and your display can output without overscan
-#disable_overscan=1
-
-# uncomment the following to adjust overscan. Use positive numbers if console
-# goes off screen, and negative if there is too much border
-#overscan_left=16
-#overscan_right=16
-#overscan_top=16
-#overscan_bottom=16
-
-# uncomment to force a console size. By default it will be display's size minus
-# overscan.
-#framebuffer_width=1280
-#framebuffer_height=720
-
-# uncomment if hdmi display is not detected and composite is being output
-#hdmi_force_hotplug=1
-
-# uncomment to force a specific HDMI mode (this will force VGA)
-#hdmi_group=1
-#hdmi_mode=1
-
-# uncomment to force a HDMI mode rather than DVI. This can make audio work in
-# DMT (computer monitor) modes
-#hdmi_drive=2
-
-# uncomment to increase signal to HDMI, if you have interference, blanking, or
-# no display
-#config_hdmi_boost=4
-
-# uncomment for composite PAL
-#sdtv_mode=2
-
-#uncomment to overclock the arm. 700 MHz is the default.
-#arm_freq=800
-
-# Uncomment some or all of these to enable the optional hardware interfaces
-#dtparam=i2c_arm=on
-#dtparam=i2s=on
-#dtparam=spi=on
-
-# Uncomment this to enable infrared communication.
-#dtoverlay=gpio-ir,gpio_pin=17
-#dtoverlay=gpio-ir-tx,gpio_pin=18
-
-# Additional overlays and parameters are documented /boot/overlays/README
-
-# Enable audio (loads snd_bcm2835)
-dtparam=audio=on
-
-# g_ether
-dtoverlay=dwc2
-
-[pi4]
-# Enable DRM VC4 V3D driver on top of the dispmanx display stack
-dtoverlay=vc4-fkms-v3d
-max_framebuffers=2
-
-[all]
+## config.txt
+#sudo tee /boot/config.txt > /dev/null <<'EOF'
+## For more options and information see
+## http://rpf.io/configtxt
+## Some settings may impact device functionality. See link above for details
+#
+## uncomment if you get no picture on HDMI for a default "safe" mode
+##hdmi_safe=1
+#
+## uncomment this if your display has a black border of unused pixels visible
+## and your display can output without overscan
+##disable_overscan=1
+#
+## uncomment the following to adjust overscan. Use positive numbers if console
+## goes off screen, and negative if there is too much border
+##overscan_left=16
+##overscan_right=16
+##overscan_top=16
+##overscan_bottom=16
+#
+## uncomment to force a console size. By default it will be display's size minus
+## overscan.
+##framebuffer_width=1280
+##framebuffer_height=720
+#
+## uncomment if hdmi display is not detected and composite is being output
+##hdmi_force_hotplug=1
+#
+## uncomment to force a specific HDMI mode (this will force VGA)
+##hdmi_group=1
+##hdmi_mode=1
+#
+## uncomment to force a HDMI mode rather than DVI. This can make audio work in
+## DMT (computer monitor) modes
+##hdmi_drive=2
+#
+## uncomment to increase signal to HDMI, if you have interference, blanking, or
+## no display
+##config_hdmi_boost=4
+#
+## uncomment for composite PAL
+##sdtv_mode=2
+#
+##uncomment to overclock the arm. 700 MHz is the default.
+##arm_freq=800
+#
+## Uncomment some or all of these to enable the optional hardware interfaces
+##dtparam=i2c_arm=on
+##dtparam=i2s=on
+##dtparam=spi=on
+#
+## Uncomment this to enable infrared communication.
+##dtoverlay=gpio-ir,gpio_pin=17
+##dtoverlay=gpio-ir-tx,gpio_pin=18
+#
+## Additional overlays and parameters are documented /boot/overlays/README
+#
+## Enable audio (loads snd_bcm2835)
+#dtparam=audio=on
+#
+## g_ether
+#dtoverlay=dwc2
+#
+#[pi4]
+## Enable DRM VC4 V3D driver on top of the dispmanx display stack
 #dtoverlay=vc4-fkms-v3d
-EOF
+#max_framebuffers=2
+#
+#[all]
+##dtoverlay=vc4-fkms-v3d
+#EOF
 
-# cmdline.txt
-sudo tee /boot/cmdline.txt > /dev/null <<'EOF'
-modules-load=dwc2,g_ether console=serial0,115200 console=tty1 root=PARTUUID=738a4d67-02 rootfstype=ext4 elevator=deadline fsck.repair=yes rootwait
-EOF
+## cmdline.txt
+#sudo tee /boot/cmdline.txt > /dev/null <<'EOF'
+#modules-load=dwc2,g_ether console=serial0,115200 console=tty1 root=PARTUUID=738a4d67-02 rootfstype=ext4 elevator=deadline fsck.repair=yes rootwait
+#EOF
 
 # co2mon
 sudo tee /etc/systemd/system/co2mon.service > /dev/null <<'EOF'

--- a/write_sd.sh
+++ b/write_sd.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
-image="${HOME}/Downloads/2020-02-13-raspbian-buster-lite.img"
+#image="${HOME}/Downloads/2020-05-27-raspios-buster-lite-armhf.img"
+image="./2020-05-27-raspios-buster-lite-armhf.img"
 
 sudo printf ''  # sudoをいちどキックしておく
 


### PR DESCRIPTION
- `write_sd.sh`で書き込むOSのバージョンを最新版にした
- 最新版のOS（RaspberryPi OS）でdwc2を指定するとOSが起動しなくなってしまったので、ひとまず無効化した（Ether Gadgetは結局あまり使ってないので当面困らないと思う）