### PR TITLE
ビルド時にbuildxを使わないようにした

### DIFF
--- a/docker_build.sh
+++ b/docker_build.sh
@@ -1,7 +1,3 @@
 #!/bin/sh
 
-#
-# --load をつけないとbuildxでビルドしたイメージをMac側に引っ張ってこれない
-#
-
-docker buildx build --platform linux/arm/v7 --load -t co2mon .
+docker build --platform linux/arm/v7 -t co2mon .


### PR DESCRIPTION
- クロスビルドに`buildx`が必要なくなったので`buildx`を使わないようにした
- `docker_build.sh` でビルドが実行できることを確認してください